### PR TITLE
Feature/key down event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.2] - Added useKeyDown parameter 
+
+* Implemented `useKeyDown` parameter to enable using `RawKeyDownEvent` instead of `RawKeyUpEvent`
+
 ## [0.1.1+1] - characterCodePoint instead of keyLabel for Windows 
 
 * Windows implementation now handles characterCodePoint instead of keyLabel

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   bloc:
     dependency: "direct main"
     description:
@@ -42,7 +42,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -384,7 +384,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -405,7 +405,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   version:
     dependency: "direct main"
     description:
@@ -449,5 +449,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/lib/flutter_barcode_listener.dart
+++ b/lib/flutter_barcode_listener.dart
@@ -119,9 +119,10 @@ class _BarcodeKeyboardListenerState extends State<BarcodeKeyboardListener> {
             ((keyEvent.data) as RawKeyEventDataWindows).characterCodePoint));
       } else if (keyEvent.data is RawKeyEventDataMacOs) {
         _controller.sink
-            .add(((keyEvent.data) as RawKeyEventDataMacOs).keyLabel);
+            .add(((keyEvent.data) as RawKeyEventDataMacOs).characters);
       } else if (keyEvent.data is RawKeyEventDataIos) {
-        _controller.sink.add(((keyEvent.data) as RawKeyEventDataIos).keyLabel);
+        _controller.sink
+            .add(((keyEvent.data) as RawKeyEventDataIos).characters);
       } else {
         _controller.sink.add(keyEvent.character);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_barcode_listener
 description: Listen for any hardware barcode scanner without any manufacturer SDK
-version: 0.1.1+1
+version: 0.1.2
 homepage: https://github.com/shaxxx/flutter_barcode_listener
 
 environment:


### PR DESCRIPTION
Implemented a parameter to use `RawKeyDownEvent` instead of `RawKeyUpEvent`. This should solve the issue for some Windows users experiencing issues with empty barcodes. 